### PR TITLE
Add DaysSupply to FHIR MedicationOrders 

### DIFF
--- a/script_facade/models/r1/medication_order.py
+++ b/script_facade/models/r1/medication_order.py
@@ -71,6 +71,17 @@ class MedicationOrder(object):
                 'quantity',
                 {'value': int(quantity_dispensed)},
             )
+        expected_supply_duration = med_dispensed.xpath('.//DaysSupply/text()')[0]
+        if expected_supply_duration:
+            dispense_request.setdefault(
+                'expectedSupplyDuration',
+                {
+                    'value': int(expected_supply_duration),
+                    'unit': 'days',
+                    'system': 'http://unitsofmeasure.org',
+                    'code': 'd',
+                },
+            )
         med_order.dispense_request = dispense_request
 
         # todo: move these extensions to a separate MedicationDispense resource

--- a/script_facade/models/r1/medication_order.py
+++ b/script_facade/models/r1/medication_order.py
@@ -64,16 +64,14 @@ class MedicationOrder(object):
         }
         med_order.prescriber = prescriber
 
-        quantity_dispensed = med_dispensed.xpath('.//Quantity/Value/text()')[0]
         dispense_request = {}
+        quantity_dispensed = med_dispensed.xpath('.//Quantity/Value/text()')[0]
         if quantity_dispensed:
-            dispense_request = {
-                'quantity': {
-                    'value': int(quantity_dispensed)
-                }
-            }
+            dispense_request.setdefault(
+                'quantity',
+                {'value': int(quantity_dispensed)},
+            )
         med_order.dispense_request = dispense_request
-
 
         # todo: move these extensions to a separate MedicationDispense resource
         pharmacy_name = med_dispensed.xpath('.//Pharmacy/StoreName/text()')[0]


### PR DESCRIPTION
Map PDMP XML `DaysSupply` to FHIR [`DaysSupply`](https://www.hl7.org/fhir/medicationrequest-definitions.html#MedicationRequest.dispenseRequest.expectedSupplyDuration)
