### PR TITLE
Use decimal values for FHIR quantities

### DIFF
--- a/script_facade/models/r1/medication_order.py
+++ b/script_facade/models/r1/medication_order.py
@@ -65,14 +65,14 @@ class MedicationOrder(object):
         if quantity_dispensed:
             dispense_request.setdefault(
                 'quantity',
-                {'value': int(quantity_dispensed)},
+                {'value': float(quantity_dispensed)},
             )
         expected_supply_duration = med_dispensed.xpath('.//DaysSupply/text()')[0]
         if expected_supply_duration:
             dispense_request.setdefault(
                 'expectedSupplyDuration',
                 {
-                    'value': int(expected_supply_duration),
+                    'value': float(expected_supply_duration),
                     'unit': 'days',
                     'system': 'http://unitsofmeasure.org',
                     'code': 'd',


### PR DESCRIPTION
[Note *Here Be Dragons* warning](https://www.hl7.org/fhir/json.html)
>When using a JavaScript JSON.parse() implementation, note that JavaScript natively supports only one numeric datatype, which is a floating point number. This can cause loss of precision for FHIR numbers. In particular, trailing 0s after a decimal point will be lost e.g. 2.00 will be converted to 2. The FHIR decimal data type is defined such that precision, including trailing zeros, is preserved for presentation purposes, and this is widely regarded as critical for correct presentation of clinical measurements. Implementations should consider using a custom parser and big number library (e.g. https://github.com/jtobey/javascript-bignum ) to meet these requirements. 