### PR TITLE
annotate MedicationOrder and MedicationRequest with source identifier

### DIFF
--- a/script_facade/client/client_106.py
+++ b/script_facade/client/client_106.py
@@ -94,7 +94,7 @@ def parse_rx_history_response(xml_string, fhir_version):
 
     meds = []
     for med_element in meds_elements:
-        meds.append(med_cls.from_xml(med_element, client_config['RX_SRC_ID']))
+        meds.append(med_cls.from_xml(med_element, client_config.RX_SRC_ID))
 
     meds = [m.as_fhir() for m in meds]
     return as_bundle(meds, bundle_type='searchset')

--- a/script_facade/client/client_106.py
+++ b/script_facade/client/client_106.py
@@ -94,7 +94,7 @@ def parse_rx_history_response(xml_string, fhir_version):
 
     meds = []
     for med_element in meds_elements:
-        meds.append(med_cls.from_xml(med_element))
+        meds.append(med_cls.from_xml(med_element, client_config['RX_SRC_ID']))
 
     meds = [m.as_fhir() for m in meds]
     return as_bundle(meds, bundle_type='searchset')

--- a/script_facade/config.py
+++ b/script_facade/config.py
@@ -4,7 +4,7 @@ Use environment variable to override
 """
 import os
 
-RX_SRC_ID = os.getenv("RX_SRC_ID", "https://pdmp")
+RX_SRC_ID = os.getenv("RX_SRC_ID", "https://github.com/uwcirg/script-fhir-facade/")
 SERVER_NAME = os.getenv("SERVER_NAME")
 SECRET_KEY = os.getenv("SECRET_KEY")
 

--- a/script_facade/config.py
+++ b/script_facade/config.py
@@ -4,6 +4,7 @@ Use environment variable to override
 """
 import os
 
+RX_SRC_ID = os.getenv("RX_SRC_ID", "https://pdmp")
 SERVER_NAME = os.getenv("SERVER_NAME")
 SECRET_KEY = os.getenv("SECRET_KEY")
 

--- a/script_facade/models/r1/medication_order.py
+++ b/script_facade/models/r1/medication_order.py
@@ -1,5 +1,3 @@
-from flask import current_app
-
 # https://www.hl7.org/fhir/terminologies-systems.html
 drug_code_system_map = {
     # todo: interpolate dashes as necessary for NDC
@@ -15,16 +13,17 @@ class MedicationOrder(object):
         self.date_written = None
         self.dispense_request = None
         self.prescriber = None
-
+        self.source_identifier = None
 
     @classmethod
-    def from_xml(cls, med_dispensed):
+    def from_xml(cls, med_dispensed, source_identifier):
         """Build a MedicationOrder from a MedicationDispensed xml element object
 
         :param med_dispensed: MedicationDispensed xml element object
 
         """
         med_order = cls()
+        med_order.source_identifier = source_identifier
 
         # todo: separate finding/extract into separate steps
         drug_description = med_dispensed.xpath('.//DrugDescription/text()')[0]
@@ -110,7 +109,7 @@ class MedicationOrder(object):
     def as_fhir(self):
         fhir_json = {
             'resourceType': 'MedicationOrder',
-            'identifier': [{'system': current_app.config['RX_SRC_ID']}],
+            'identifier': [{'system': self.source_identifier}],
             'dateWritten': self.date_written,
             'medicationCodeableConcept': self.medication,
             'dispenseRequest': self.dispense_request,

--- a/script_facade/models/r1/medication_order.py
+++ b/script_facade/models/r1/medication_order.py
@@ -1,3 +1,5 @@
+from flask import current_app
+
 # https://www.hl7.org/fhir/terminologies-systems.html
 drug_code_system_map = {
     # todo: interpolate dashes as necessary for NDC
@@ -108,6 +110,7 @@ class MedicationOrder(object):
     def as_fhir(self):
         fhir_json = {
             'resourceType': 'MedicationOrder',
+            'identifier': [{'system': current_app.config['RX_SRC_ID']}],
             'dateWritten': self.date_written,
             'medicationCodeableConcept': self.medication,
             'dispenseRequest': self.dispense_request,

--- a/script_facade/models/r4/medication_request.py
+++ b/script_facade/models/r4/medication_request.py
@@ -1,5 +1,3 @@
-from flask import current_app
-
 # https://www.hl7.org/fhir/terminologies-systems.html
 drug_code_system_map = {
     # todo: interpolate dashes as necessary for NDC
@@ -15,16 +13,17 @@ class MedicationRequest(object):
         self.authored_on = None
         self.dispense_request = None
         self.requester = None
-
+        self.source_identifier = None
 
     @classmethod
-    def from_xml(cls, med_dispensed):
+    def from_xml(cls, med_dispensed, source_identifier):
         """Build a MedicationRequest from a MedicationDispensed xml element object
 
         :param med_dispensed: MedicationDispensed xml element object
 
         """
         med_order = cls()
+        med_order.source_identifier = source_identifier
 
         # todo: separate finding/extract into separate steps
         drug_description = med_dispensed.xpath('.//DrugDescription/text()')[0]
@@ -110,7 +109,7 @@ class MedicationRequest(object):
     def as_fhir(self):
         fhir_json = {
             'resourceType': 'MedicationRequest',
-            'identifier': [{'system': current_app.config['RX_SRC_ID']}],
+            'identifier': [{'system': self.source_identifier}],
             'authoredOn': self.authored_on,
             'medicationCodeableConcept': self.medication,
             'dispenseRequest': self.dispense_request,

--- a/script_facade/models/r4/medication_request.py
+++ b/script_facade/models/r4/medication_request.py
@@ -1,3 +1,5 @@
+from flask import current_app
+
 # https://www.hl7.org/fhir/terminologies-systems.html
 drug_code_system_map = {
     # todo: interpolate dashes as necessary for NDC
@@ -108,6 +110,7 @@ class MedicationRequest(object):
     def as_fhir(self):
         fhir_json = {
             'resourceType': 'MedicationRequest',
+            'identifier': [{'system': current_app.config['RX_SRC_ID']}],
             'authoredOn': self.authored_on,
             'medicationCodeableConcept': self.medication,
             'dispenseRequest': self.dispense_request,


### PR DESCRIPTION
Simple addition of an 'identifier' to MedicationOrder and MedicationRequest for clients to differentiate data source.  Uses configured value named `RX_SRC_ID`