### PR TITLE
Add GitHub CI for automated tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,18 @@
+# docker continuous integration
+# run tests
+---
+name: Test
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container: python:3.7
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Install test runner
+        run: python3 -m pip install tox
+
+      - name: Run tests
+        run: tox


### PR DESCRIPTION
Run `tox` with current version of python in debian stable (3.7)