### PR TITLE
Confirm expected no match found error code on empty PDMP response

### DIFF
--- a/script_facade/api/fhir.py
+++ b/script_facade/api/fhir.py
@@ -56,6 +56,9 @@ def patient_search(fhir_version):
     patient_dob = request.args.get('subject:Patient.birthdate', '').split('eq')[-1]
 
     if not all((patient_fname, patient_lname, patient_dob)):
+        current_app.logger.warning(
+            "patient search attempted without all required parameters"
+            "{fname: %s, lname: %s, dob: %s", patient_fname, patient_lname, patient_dob)
         return 'Required parameters not given', 400
 
     script_version = request.args.get('script_version')

--- a/script_facade/client/client.py
+++ b/script_facade/client/client.py
@@ -122,7 +122,8 @@ def parse_rx_history_response(xml_string, fhir_version, script_version):
 
 def parse_patient_lookup_query(xml_string, script_version):
     # LXML infers encoding from XML metadata
-    root = ET.fromstring(xml_string.encode('utf-8'))
+    parser = ET.XMLParser(dtd_validation=True)
+    root = parser.fromstring(xml_string.encode('utf-8'))
 
     patient_script_version_map = {
         '106': '//script:Patient',

--- a/script_facade/client/client.py
+++ b/script_facade/client/client.py
@@ -6,6 +6,7 @@ from lxml import etree as ET
 import requests_cache
 import requests
 from requests import Request, Session
+from werkzeug.exceptions import InternalServerError
 
 from script_facade.models.r1.bundle import as_bundle
 from script_facade.models.r1.medication_order import MedicationOrder
@@ -138,9 +139,20 @@ def parse_patient_lookup_query(xml_string, script_version):
 
     patients = []
     for patient_element in patient_elements:
-        patients.append(Patient.from_xml(patient_element, ns=SCRIPT_NAMESPACE))
+        patient = Patient.from_xml(patient_element, ns=SCRIPT_NAMESPACE)
+        patients.append(patient.as_fhir())
 
-    patients = [p.as_fhir() for p in patients]
+    if len(patients) == 0:
+        # Confirm expected no match code is present.  Otherwise
+        # log and raise to avoid masking errors
+        codes = root.findall('Body/Error/Code')
+        if len(codes) == 1 and codes[0].text == '900':
+            nomatch = True
+        else:
+            current_app.logger.error(
+                "no patients; didn't find expected PDMP no-match error code within: %s",
+                xml_string)
+            raise InternalServerError("Unexpected PDMP response")
     return as_bundle(patients, bundle_type='searchset')
 
 

--- a/tests/test_patient_query.py
+++ b/tests/test_patient_query.py
@@ -1,0 +1,29 @@
+import os
+import pytest
+from werkzeug.exceptions import InternalServerError
+
+from script_facade.client.client import parse_patient_lookup_query
+
+@pytest.fixture
+def no_results_response(datadir):
+    with open(os.path.join(datadir, 'no_results.xml'), 'r') as xml_file:
+        data = xml_file.read()
+    return data
+
+
+def test_no_results(no_results_response):
+    results = parse_patient_lookup_query(
+        xml_string=no_results_response, script_version='20170701')
+    assert results['resourceType'] == 'Bundle'
+    assert len(results['entry']) == 0
+
+
+def test_no_results_wo_expected(client, no_results_response):
+    # who knows what unexpected to check for - remove the
+    # published error on no match and expect a raise
+    bogus_results_response = no_results_response.replace(
+        '<Code>900</Code>', '<Code>666</Code>')
+    with pytest.raises(InternalServerError):
+        parse_patient_lookup_query(
+            xml_string=bogus_results_response,
+            script_version='20170701')

--- a/tests/test_patient_query/no_results.xml
+++ b/tests/test_patient_query/no_results.xml
@@ -1,0 +1,22 @@
+ <Message xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" StructuresVersion="20170715" ECLVersion="20170715" DatatypesVersion="20170715" TransactionDomain="SCRIPT" TransactionVersion="20170715" TransportVersion="20170715">
+     <Header>
+         <To Qualifier="D">7uycso03</To>
+         <From Qualifier="ZZZ">WA-OHP</From>
+         <MessageID>MESAGE1234567890</MessageID>
+         <RelatesToMessageID>MESAGE1234567890</RelatesToMessageID>
+         <SentTime>2021-07-15T19:21:01+00:00</SentTime>
+         <SenderSoftware>
+             <SenderSoftwareDeveloper>N/A</SenderSoftwareDeveloper>
+             <SenderSoftwareProduct>N/A</SenderSoftwareProduct>
+             <SenderSoftwareVersionRelease>N/A</SenderSoftwareVersionRelease>
+         </SenderSoftware>
+         <TertiaryIdentifier>ABC</TertiaryIdentifier>
+     </Header>
+     <Body>
+         <Error>
+             <Code>900</Code>
+             <DescriptionCode>1000</DescriptionCode>
+             <Description>NotFound</Description>
+         </Error>
+     </Body>
+ </Message>


### PR DESCRIPTION
PDMP is documented to return, on a valid no-match-found, XML detailing exactly that.

Confirm we get the expected error code, or log and raise so unexpected responses aren't overlooked.
Also raising should we ever receive invalid (un-parsable) XML.

In all of the above, a 500 is raised with a user friendly reason for UI display.