### PR TITLE
jsonify_abort() utility function added

### DIFF
--- a/script_facade/api/misc.py
+++ b/script_facade/api/misc.py
@@ -1,5 +1,7 @@
-from flask import Blueprint, abort, current_app, jsonify
+from flask import Blueprint, current_app, jsonify
 from flask.json import JSONEncoder
+
+from script_facade.jsonify_abort import jsonify_abort
 
 blueprint = Blueprint('misc', __name__)
 
@@ -22,7 +24,7 @@ def config_settings(config_key):
         key = config_key.upper()
         for pattern in blacklist:
             if pattern in key:
-                abort(400, f"Configuration key {key} not available")
+                jsonify_abort(status_code=400, message=f"Configuration key {key} not available")
         return jsonify({key: current_app.config.get(key)})
 
     results = {}

--- a/script_facade/client/client.py
+++ b/script_facade/client/client.py
@@ -1,13 +1,14 @@
 """Client for NCPDP SCRIPT Standard version 10.6"""
 from datetime import datetime
 
-from flask import abort, current_app
+from flask import current_app
 from lxml import etree as ET
 import requests_cache
 import requests
 from requests import Request, Session
 from werkzeug.exceptions import InternalServerError
 
+from script_facade.jsonify_abort import jsonify_abort
 from script_facade.models.r1.bundle import as_bundle
 from script_facade.models.r1.medication_order import MedicationOrder
 from script_facade.models.r4.medication_request import medication_request_factory, SCRIPT_NAMESPACE
@@ -128,7 +129,7 @@ def parse_patient_lookup_query(xml_string, script_version):
         root = ET.fromstring(xml_string.encode('utf-8'))
     except ET.XMLSyntaxError as se:
         current_app.logger.error("Couldn't parse PDMP XML: %s", se)
-        abort(500, "Invalid XML returned from PDMP")
+        return jsonify_abort(message="Invalid XML returned from PDMP", status_code=500)
 
     patient_script_version_map = {
         '106': '//script:Patient',

--- a/script_facade/jsonify_abort.py
+++ b/script_facade/jsonify_abort.py
@@ -1,0 +1,9 @@
+"""Utility function to bring together flask `abort` and `jsonify`"""
+from flask import abort, jsonify, make_response
+
+def jsonify_abort(**kwargs):
+    """Takes any number of args, like jsonify, but raises like abort with correct content_type heading"""
+    status_code = kwargs.pop('status_code', 500)
+    response = make_response(jsonify(kwargs))
+    response.status_code = status_code
+    abort(response)


### PR DESCRIPTION
`jsonify_abort()` brings together flasks like named functions, to `abort` on error, with jsonify content type and args.

fix for https://www.pivotaltracker.com/story/show/179256662 - within this repository, at least