### PR TITLE
Catch and bubble up invalid PDMP certificate issues.

### DIFF
--- a/script_facade/api/fhir.py
+++ b/script_facade/api/fhir.py
@@ -28,7 +28,7 @@ def required_search_request_params(req, fhir_version, context):
             "%s search attempted without all required parameters"
             "{fname: %s, lname: %s, dob: %s, DEA: %s}",
             context, patient_fname, patient_lname, patient_dob, DEA)
-        jsonify_abort(message='Required parameters not given', status_code=400)
+        return jsonify_abort(message='Required parameters not given', status_code=400)
 
     return {
         'patient_fname': patient_fname,

--- a/script_facade/api/fhir.py
+++ b/script_facade/api/fhir.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, jsonify, request, current_app
+from flask import Blueprint, request, current_app
 import timeit
 
 from script_facade.client.client import rx_history_query, patient_lookup_query
@@ -15,7 +15,7 @@ def required_search_request_params(req, fhir_version, context):
     :param req: the live request
     :param context: calling context used in exception text
     :returns: dictionary of required and optional search parameters
-    :raises: BadRequest if any required parameters are missing
+    :raises: ValueError if any required parameters are missing
 
     """
     patient_fname = req.args.get('subject:Patient.name.given')
@@ -28,7 +28,7 @@ def required_search_request_params(req, fhir_version, context):
             "%s search attempted without all required parameters"
             "{fname: %s, lname: %s, dob: %s, DEA: %s}",
             context, patient_fname, patient_lname, patient_dob, DEA)
-        return jsonify_abort(message='Required parameters not given', status_code=400)
+        raise ValueError('Required parameters not given')
 
     return {
         'patient_fname': patient_fname,
@@ -53,7 +53,10 @@ def audit_entry(context, tags, **kwargs):
 # ?patient=PATIENT_ID
 @blueprint.route('/v/<fhir_version>/fhir/MedicationOrder')
 def medication_order(fhir_version):
-    kwargs = required_search_request_params(request, fhir_version, 'MedicationOrder')
+    try:
+        kwargs = required_search_request_params(request, fhir_version, 'MedicationOrder')
+    except ValueError as error:
+        jsonify_abort(message=str(error), status_code=400)
 
     audit_entry(context='MedicationOrder', tags=['PDMP', 'search'], **kwargs)
     rx_history_start_time = timeit.default_timer()
@@ -79,8 +82,14 @@ def medication_order(fhir_version):
 # ?patient=PATIENT_ID
 @blueprint.route('/v/<fhir_version>/fhir/Patient')
 def patient_search(fhir_version):
-    kwargs = required_search_request_params(request, fhir_version, 'Patient')
+    try:
+        kwargs = required_search_request_params(request, fhir_version, 'Patient')
+    except ValueError as error:
+        jsonify_abort(message=str(error), status_code=400)
 
     audit_entry(context='Patient', tags=['PDMP', 'search'], **kwargs)
-    patient_bundle = patient_lookup_query(**kwargs)
+    try:
+        patient_bundle = patient_lookup_query(**kwargs)
+    except RuntimeError as error:
+        return jsonify_abort(status_code=400, message=str(error))
     return patient_bundle

--- a/script_facade/api/misc.py
+++ b/script_facade/api/misc.py
@@ -24,7 +24,7 @@ def config_settings(config_key):
         key = config_key.upper()
         for pattern in blacklist:
             if pattern in key:
-                jsonify_abort(status_code=400, message=f"Configuration key {key} not available")
+                return jsonify_abort(status_code=400, message=f"Configuration key {key} not available")
         return jsonify({key: current_app.config.get(key)})
 
     results = {}

--- a/script_facade/client/client.py
+++ b/script_facade/client/client.py
@@ -133,7 +133,7 @@ def parse_patient_lookup_query(xml_string, script_version):
         root = ET.fromstring(xml_string.encode('utf-8'))
     except ET.XMLSyntaxError as se:
         current_app.logger.error("Couldn't parse PDMP XML: %s", se)
-        jsonify_abort(message="Invalid XML returned from PDMP", status_code=500)
+        return jsonify_abort(message="Invalid XML returned from PDMP", status_code=500)
 
     patient_script_version_map = {
         '106': '//script:Patient',
@@ -157,7 +157,7 @@ def parse_patient_lookup_query(xml_string, script_version):
             current_app.logger.error(
                 "no patients; didn't find expected PDMP no-match error code within: %s",
                 xml_string)
-            jsonify_abort(message="Unexpected PDMP response", status_code=400)
+            return jsonify_abort(message="Unexpected PDMP response", status_code=400)
     return as_bundle(patients, bundle_type='searchset')
 
 
@@ -215,7 +215,7 @@ def patient_lookup_query(patient_fname, patient_lname, patient_dob, DEA, script_
             response = s.send(request, **session_data)
         except OSError as e:
             current_app.logger.error("Missing PDMP certificates: %s", e)
-            jsonify_abort(message="Valid PDMP certificates not found", status_code=400)
+            return jsonify_abort(message="Valid PDMP certificates not found", status_code=400)
         response.raise_for_status()
 
         xml_body = response.text

--- a/script_facade/client/client.py
+++ b/script_facade/client/client.py
@@ -133,7 +133,7 @@ def parse_patient_lookup_query(xml_string, script_version):
         root = ET.fromstring(xml_string.encode('utf-8'))
     except ET.XMLSyntaxError as se:
         current_app.logger.error("Couldn't parse PDMP XML: %s", se)
-        return jsonify_abort(message="Invalid XML returned from PDMP", status_code=500)
+        jsonify_abort(message="Invalid XML returned from PDMP", status_code=500)
 
     patient_script_version_map = {
         '106': '//script:Patient',
@@ -157,7 +157,7 @@ def parse_patient_lookup_query(xml_string, script_version):
             current_app.logger.error(
                 "no patients; didn't find expected PDMP no-match error code within: %s",
                 xml_string)
-            raise InternalServerError("Unexpected PDMP response")
+            jsonify_abort(message="Unexpected PDMP response", status_code=400)
     return as_bundle(patients, bundle_type='searchset')
 
 
@@ -211,7 +211,11 @@ def patient_lookup_query(patient_fname, patient_lname, patient_dob, DEA, script_
         request_builder = RxRequest(url=api_endpoint, DEA=DEA, script_version=script_version)
         request = request_builder.build_request(patient_fname, patient_lname, patient_dob)
         s = Session()
-        response = s.send(request, **session_data)
+        try:
+            response = s.send(request, **session_data)
+        except OSError as e:
+            current_app.logger.error("Missing PDMP certificates: %s", e)
+            jsonify_abort(message="Valid PDMP certificates not found", status_code=400)
         response.raise_for_status()
 
         xml_body = response.text

--- a/script_facade/client/client.py
+++ b/script_facade/client/client.py
@@ -6,9 +6,7 @@ from lxml import etree as ET
 import requests_cache
 import requests
 from requests import Request, Session
-from werkzeug.exceptions import InternalServerError
 
-from script_facade.jsonify_abort import jsonify_abort
 from script_facade.models.r1.bundle import as_bundle
 from script_facade.models.r1.medication_order import MedicationOrder
 from script_facade.models.r4.medication_request import medication_request_factory, SCRIPT_NAMESPACE
@@ -133,7 +131,7 @@ def parse_patient_lookup_query(xml_string, script_version):
         root = ET.fromstring(xml_string.encode('utf-8'))
     except ET.XMLSyntaxError as se:
         current_app.logger.error("Couldn't parse PDMP XML: %s", se)
-        return jsonify_abort(message="Invalid XML returned from PDMP", status_code=500)
+        raise RuntimeError("Invalid XML returned from PDMP")
 
     patient_script_version_map = {
         '106': '//script:Patient',
@@ -157,7 +155,7 @@ def parse_patient_lookup_query(xml_string, script_version):
             current_app.logger.error(
                 "no patients; didn't find expected PDMP no-match error code within: %s",
                 xml_string)
-            return jsonify_abort(message="Unexpected PDMP response", status_code=400)
+            raise RuntimeError("Unexpected PDMP response")
     return as_bundle(patients, bundle_type='searchset')
 
 
@@ -215,7 +213,7 @@ def patient_lookup_query(patient_fname, patient_lname, patient_dob, DEA, script_
             response = s.send(request, **session_data)
         except OSError as e:
             current_app.logger.error("Missing PDMP certificates: %s", e)
-            return jsonify_abort(message="Valid PDMP certificates not found", status_code=400)
+            raise RuntimeError("Valid PDMP certificates not found")
         response.raise_for_status()
 
         xml_body = response.text

--- a/script_facade/jsonify_abort.py
+++ b/script_facade/jsonify_abort.py
@@ -1,10 +1,12 @@
-"""Utility function to bring together flask `abort` and `jsonify`"""
-from flask import abort, jsonify, make_response
+"""Utility function to generate JSON response with error (status_code)"""
+from flask import jsonify, make_response
 
 
-def jsonify_abort(**kwargs):
-    """Takes any number of args, like jsonify, but raises like abort with correct content_type heading"""
-    status_code = kwargs.pop('status_code', 500)
+def jsonify_abort(status_code, **kwargs):
+    """Given kwards included in JSON response using given status_code
+
+    NB - must return from view
+    """
     response = make_response(jsonify(kwargs))
     response.status_code = status_code
-    abort(status_code, response)
+    return response

--- a/script_facade/jsonify_abort.py
+++ b/script_facade/jsonify_abort.py
@@ -3,9 +3,9 @@ from flask import jsonify, make_response
 
 
 def jsonify_abort(status_code, **kwargs):
-    """Given kwards included in JSON response using given status_code
+    """Given kwargs included in JSON response using given status_code
 
-    NB - must return from view
+    NB - must return from view - does not raise from nested call
     """
     response = make_response(jsonify(kwargs))
     response.status_code = status_code

--- a/script_facade/jsonify_abort.py
+++ b/script_facade/jsonify_abort.py
@@ -1,9 +1,10 @@
 """Utility function to bring together flask `abort` and `jsonify`"""
 from flask import abort, jsonify, make_response
 
+
 def jsonify_abort(**kwargs):
     """Takes any number of args, like jsonify, but raises like abort with correct content_type heading"""
     status_code = kwargs.pop('status_code', 500)
     response = make_response(jsonify(kwargs))
     response.status_code = status_code
-    abort(response)
+    abort(status_code, response)

--- a/tests/test_patient_query.py
+++ b/tests/test_patient_query.py
@@ -1,8 +1,8 @@
 import os
 import pytest
-from werkzeug.exceptions import BadRequest
 
 from script_facade.client.client import parse_patient_lookup_query
+
 
 @pytest.fixture
 def no_results_response(datadir):
@@ -23,7 +23,7 @@ def test_no_results_wo_expected(client, no_results_response):
     # published error on no match and expect a raise
     bogus_results_response = no_results_response.replace(
         '<Code>900</Code>', '<Code>666</Code>')
-    with pytest.raises(BadRequest):
+    with pytest.raises(RuntimeError):
         parse_patient_lookup_query(
             xml_string=bogus_results_response,
             script_version='20170701')

--- a/tests/test_patient_query.py
+++ b/tests/test_patient_query.py
@@ -1,6 +1,6 @@
 import os
 import pytest
-from werkzeug.exceptions import InternalServerError
+from werkzeug.exceptions import BadRequest
 
 from script_facade.client.client import parse_patient_lookup_query
 
@@ -23,7 +23,7 @@ def test_no_results_wo_expected(client, no_results_response):
     # published error on no match and expect a raise
     bogus_results_response = no_results_response.replace(
         '<Code>900</Code>', '<Code>666</Code>')
-    with pytest.raises(InternalServerError):
+    with pytest.raises(BadRequest):
         parse_patient_lookup_query(
             xml_string=bogus_results_response,
             script_version='20170701')


### PR DESCRIPTION
Fix for https://www.pivotaltracker.com/story/show/179458390 - see for reproduction details and screen shot.

Along the way, discovered `jsonify_abort` does NOT reliably raise from deep within the call stack, and if forced to do so, we mangle the desired message and content-type.  Refactored to require a clean `return jsonify_abort` from view functions only, and raise exceptions w/i call stack.