### PR TITLE
Replace Dockerhub with GHCR

### DIFF
--- a/.github/workflows/docker-cd.yaml
+++ b/.github/workflows/docker-cd.yaml
@@ -8,16 +8,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout git commit
-        uses: actions/checkout@master
+        uses: actions/checkout@main
 
-      - name: Publish to Dockerhub registry
+      - name: Publish to GitHub Container Registry
         # todo: pin to hash
-        uses: elgohr/Publish-Docker-Github-Action@3.04
+        uses: elgohr/Publish-Docker-Github-Action@main
         with:
-          # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions
           name: ${{ github.repository }}
-          # configured at repo settings/secrets
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ghcr.io
+
+          # GitHub actor
+          username: ${{ github.actor }}
+
+          # GitHub access token
+          password: ${{ secrets.GITHUB_TOKEN }}
+
           # create docker image tags to match git tags
           tag_names: true


### PR DESCRIPTION
Push container images to GitHub Container Registry instead of Dockerhub