### PR TITLE
Fixup FHIR Bundles

### DIFF
--- a/script_facade/models/r1/bundle.py
+++ b/script_facade/models/r1/bundle.py
@@ -1,7 +1,7 @@
 def as_bundle(fhir_resources, bundle_type='collection'):
     entries = []
     for fhir_resource in fhir_resources:
-        entries.append(fhir_resource)
+        entries.append({"resource": fhir_resource})
 
     bundle_fhir = {
         "resourceType": 'Bundle',

--- a/script_facade/rxnav/transcode.py
+++ b/script_facade/rxnav/transcode.py
@@ -34,7 +34,7 @@ def add_rxnorm_coding(medication_order_bundle, rxnav_url):
     """Add rxnorm codings to each MedicationOrder in given FHIR bundle"""
     medication_order_bundle = medication_order_bundle.copy()
     for medication_order in medication_order_bundle['entry']:
-        medication = medication_order['medicationCodeableConcept']
+        medication = medication_order['resource']['medicationCodeableConcept']
         rxnorm_codings = []
         for coding in medication['coding']:
             # skip non-NDC codings

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -19,9 +19,9 @@ def test_meds_bundle(rxhistory_response_20170701):
     )
     assert len(meds_bundle['entry']) == 10
 
-    assert meds_bundle['entry'][0]['medicationCodeableConcept']['text'] == 'TESTOSTERONE PROPIONATE POWDER'
-    assert meds_bundle['entry'][5]['medicationCodeableConcept']['text'] == 'FORTICAL 200 UNITS NASAL SPRAY'
-    assert meds_bundle['entry'][7]['medicationCodeableConcept']['text'] == 'DIAZEPAM 10 MG TABLET'
+    assert meds_bundle['entry'][0]['resource']['medicationCodeableConcept']['text'] == 'TESTOSTERONE PROPIONATE POWDER'
+    assert meds_bundle['entry'][5]['resource']['medicationCodeableConcept']['text'] == 'FORTICAL 200 UNITS NASAL SPRAY'
+    assert meds_bundle['entry'][7]['resource']['medicationCodeableConcept']['text'] == 'DIAZEPAM 10 MG TABLET'
 
 
 def test_script_20170701(rxhistory_response_20170701):


### PR DESCRIPTION
Fixup FHIR Bundle compliance: add missing `resource` nesting ([see R4 Bundle spec](https://www.hl7.org/implement/standards/fhir/r4/bundle-definitions.html#Bundle.entry.resource))

[PT#188585370](https://www.pivotaltracker.com/story/show/188585370)