### PR TITLE
PDMP XML whitespace workaround

### DIFF
--- a/script_facade/client/templates/request_20170701.xml
+++ b/script_facade/client/templates/request_20170701.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Message StructuresVersion="20170715" ECLVersion="20170715" DatatypesVersion="20170715"
-TransactionDomain="SCRIPT" TransactionVersion="20170715" TransportVersion="20170715"
+<Message StructuresVersion="20170715" ECLVersion="20170715" DatatypesVersion="20170715" 
+TransactionDomain="SCRIPT" TransactionVersion="20170715" TransportVersion="20170715" 
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Header>
         <To Qualifier="ZZZ">WA-OHP</To>


### PR DESCRIPTION
- Add workaround for Bamboo Health non-standard behavior
  - Ensure XML attributes are separated by at least once space


[See Shortcut](https://app.shortcut.com/cirg/story/2023/cosri-error-ohp-change-breaks-pdmp-data)
#### TODO 
- [ ] Review/compare NCPDP SCRIPT standard and application XML representation

See [Shortcut](https://app.shortcut.com/cirg/story/2023/cosri-error-ohp-change-breaks-pdmp-data)